### PR TITLE
add destroyWindow() and destroyAllWindows() to public API

### DIFF
--- a/imshow.h
+++ b/imshow.h
@@ -55,7 +55,9 @@ struct Image
 
 void imshow(const char * name, const Image &image);
 char getKey(bool wait = false);
-
+void destroyWindow(const char *name);
+void destroyAllWindows();
+    
 inline ImType getImType(const cv::Mat &image)
 {
     switch (image.depth())


### PR DESCRIPTION
Initial hunterized release:

original: https://github.com/leonidk/imshow

* add hunter friendly cmake  w/ optional opencv support
* package config installation
* add destroyWindow() and destroyAllWindows() to public API
* cleanups (add namespace macros (prevent ide indentation))
* migrate window related globals into common glfwState class
* support init and shutdown as needed: (glfw{Init,Terminate})
* multi-windows fixes
* complete callback list functionality

```
        glfwSetKeyCallback(window, key_callback);
        glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
        glfwSetWindowRefreshCallback(window, render_callback);
        glfwSetWindowFocusCallback(window, focus_callback);
        glfwSetWindowPosCallback(window, position_callback);
        glfwSetWindowRefreshCallback(window, refresh_callback);
        glfwSetWindowCloseCallback(window, window_close_callback);
```
